### PR TITLE
fix: Handle division by zero in poll percentage calculation when no votes cast

### DIFF
--- a/src/components/PollResults/Analytics.tsx
+++ b/src/components/PollResults/Analytics.tsx
@@ -65,6 +65,9 @@ export const Analytics: React.FC<AnalyticsProps> = ({
 
   const calculatePercentages = (counts: number[]) => {
     const total = counts.reduce((acc, count) => acc + count, 0);
+    if (total === 0) {
+      return counts.map(() => "0.00");
+    }
     return counts.map((count) => ((count / total) * 100).toFixed(2));
   };
 


### PR DESCRIPTION
## Summary
Fixes division by zero error when calculating poll percentages with no votes, preventing NaN values in the UI.

## Changes
- Added zero-total check in `calculatePercentages` function to return "0.00" when no votes exist

## Impact
- Prevents display of NaN percentages for polls without votes

---
*This pull request was created using GitHub Copilot.*