### PR TITLE
fix: Update movie card placeholder background to use theme colors

### DIFF
--- a/src/components/Movies/MovieCard.tsx
+++ b/src/components/Movies/MovieCard.tsx
@@ -93,7 +93,7 @@ const MovieCard: React.FC<MovieCardProps> = ({ imdbId, metadataEvent }) => {
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              bgcolor: "grey.200",
+              bgcolor: "action.hover"
             }}
           >
             <Button size="small" onClick={() => setModalOpen(true)}>


### PR DESCRIPTION
## Summary
Updates MovieCard placeholder to use Material-UI theme colors for better theme consistency.

## Changes
- Replace hardcoded `grey.200` with `action.hover` theme color

## Impact
- Improved dark mode support and visual consistency

---
*This pull request was created using GitHub Copilot.*