### PR TITLE
feat: Add preview functionality to note and poll creator

### DIFF
--- a/src/components/EventCreator/NotePreview.tsx
+++ b/src/components/EventCreator/NotePreview.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Event } from 'nostr-tools';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box,
+} from '@mui/material';
+import { Notes } from '../Notes';
+import { useUserContext } from '../../hooks/useUserContext';
+import { NOSTR_EVENT_KINDS } from "../../constants/nostr";
+
+interface NotePreviewProps {
+  noteEvent: Partial<Event>;
+}
+
+export const NotePreview: React.FC<NotePreviewProps> = ({ noteEvent }) => {
+  const { user } = useUserContext();
+  const previewPubkey = user?.pubkey || 'preview-pubkey';
+
+  return (
+    <Card variant="outlined" sx={{ mt: 2, mb: 2, minHeight: 200 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Note Preview
+        </Typography>
+        {!noteEvent.content?.trim() ? (
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight={100}
+            sx={{ opacity: 0.6 }}
+          >
+            <Typography variant="body2" color="textSecondary">
+              Start typing to see a preview of your note
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ opacity: 0.8, pointerEvents: 'none' }}>
+            <Notes event={{
+              id: 'preview-note-id',
+              pubkey: previewPubkey,
+              created_at: Math.floor(Date.now() / 1000),
+              kind: NOSTR_EVENT_KINDS.TEXT_NOTE,
+              tags: [],
+              content: noteEvent.content || '',
+              sig: 'preview-note-id',
+            }} />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/EventCreator/NoteTemplateForm.tsx
+++ b/src/components/EventCreator/NoteTemplateForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Button, Stack, TextField } from "@mui/material";
+import { Box, Button, Stack, TextField, Collapse } from "@mui/material";
 import { useSigner } from "../../contexts/signer-context";
 import { useNotification } from "../../contexts/notification-context";
 import { useAppContext } from "../../hooks/useAppContext";
@@ -8,14 +8,23 @@ import { useNavigate } from "react-router-dom";
 import { NOTIFICATION_MESSAGES } from "../../constants/notifications";
 import { NOSTR_EVENT_KINDS } from "../../constants/nostr";
 import { defaultRelays, signEvent } from "../../nostr";
+import { Event } from "nostr-tools";
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { NotePreview } from "./NotePreview";
 
 const NoteTemplateForm: React.FC<{ eventContent: string; setEventContent: (val: string) => void }> = ({ eventContent, setEventContent }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
   const { signer, requestLogin } = useSigner();
   const { showNotification } = useNotification();
   const { poolRef } = useAppContext();
   const { user } = useUserContext();
   const navigate = useNavigate();
+
+  const previewEvent: Partial<Event> = {
+    content: eventContent,
+  };
 
   const publishNoteEvent = async (secret?: string) => {
     try {
@@ -74,15 +83,31 @@ const NoteTemplateForm: React.FC<{ eventContent: string; setEventContent: (val: 
           />
         </Box>
         <Box sx={{ pt: 2 }}>
-          <Button
-            type="submit"
-            variant="contained"
-            size="large"
-            fullWidth
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? "Creating Note..." : "Create Note"}
-          </Button>
+          <Box display="flex" flexDirection="column" gap={2}>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Creating Note..." : "Create Note"}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={showPreview ? <VisibilityOffIcon /> : <VisibilityIcon />}
+              onClick={(e) => {
+                e.preventDefault();
+                setShowPreview(!showPreview);
+              }}
+              fullWidth
+            >
+              {showPreview ? 'Hide Preview' : 'Show Preview'}
+            </Button>
+            <Collapse in={showPreview}>
+              <Box mt={1}>
+                <NotePreview noteEvent={previewEvent} />
+              </Box>
+            </Collapse>
+          </Box>
         </Box>
       </Stack>
     </form>

--- a/src/components/EventCreator/PollPreview.tsx
+++ b/src/components/EventCreator/PollPreview.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Event } from 'nostr-tools';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Box
+} from '@mui/material';
+import PollResponseForm from '../PollResponse/PollResponseForm';
+import { useUserContext } from '../../hooks/useUserContext';
+import { NOSTR_EVENT_KINDS } from "../../constants/nostr";
+
+interface PollPreviewProps {
+  pollEvent: Partial<Event>;
+}
+
+export const PollPreview: React.FC<PollPreviewProps> = ({ pollEvent }) => {
+  const { user } = useUserContext();
+  const previewPubkey = user?.pubkey || 'preview-pubkey';
+
+  return (
+    <Card variant="outlined" sx={{ mt: 2, mb: 2, minHeight: 200 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Poll Preview
+        </Typography>
+        {!pollEvent.content?.trim() ? (
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight={100}
+            sx={{ opacity: 0.6 }}
+          >
+            <Typography variant="body2" color="textSecondary">
+              Enter a poll question to see the preview
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ opacity: 0.8, pointerEvents: 'none' }}>
+            <PollResponseForm
+              pollEvent={{
+                id: 'preview-poll-id',
+                pubkey: previewPubkey,
+                created_at: Math.floor(Date.now() / 1000),
+                kind: NOSTR_EVENT_KINDS.POLL,
+                tags: [...(pollEvent.tags || [])],
+                content: pollEvent.content || '',
+                sig: 'preview-poll-id',
+              }}
+            />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/EventCreator/PollTemplateForm.tsx
+++ b/src/components/EventCreator/PollTemplateForm.tsx
@@ -9,7 +9,10 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Collapse,
 } from "@mui/material";
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Grid from '@mui/material/Grid2';
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DateTimePicker } from "@mui/x-date-pickers";
@@ -28,10 +31,12 @@ import { useNavigate } from "react-router-dom";
 import { NOTIFICATION_MESSAGES } from "../../constants/notifications";
 import { NOSTR_EVENT_KINDS } from "../../constants/nostr";
 import { defaultRelays, signEvent } from "../../nostr";
+import { PollPreview } from "./PollPreview";
+import { Event } from "nostr-tools";
 
 const generateOptionId = (): string => {
   return Math.random().toString(36).substr(2, 9);
-}; 
+};
 
 const pollOptions = [
   {
@@ -53,6 +58,7 @@ const pollOptions = [
 ];
 
 const PollTemplateForm: React.FC<{ eventContent: string; setEventContent: (val: string) => void }> = ({ eventContent, setEventContent }) => {
+  const [showPreview, setShowPreview] = useState(false);
   const [options, setOptions] = useState<Option[]>([
     [generateOptionId(), ""],
     [generateOptionId(), ""],
@@ -134,6 +140,16 @@ const PollTemplateForm: React.FC<{ eventContent: string; setEventContent: (val: 
 
   const handleChange = (event: any) => {
     setPollType(event.target.value);
+  };
+
+  const previewEvent: Partial<Event> = {
+    content: eventContent,
+    tags: [
+      ...options.map((option: Option) => ["option", option[0], option[1]]),
+      ["polltype", pollType],
+      ...(expiration ? [["endsAt", expiration.toString()]] : []),
+      ...(poW ? [["PoW", poW.toString()]] : []),
+    ],
   };
 
   return (
@@ -233,15 +249,27 @@ const PollTemplateForm: React.FC<{ eventContent: string; setEventContent: (val: 
           />
         </Box>
         <Box sx={{ pt: 2 }}>
-          <Button
-            type="submit"
-            variant="contained"
-            size="large"
-            fullWidth
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? "Creating Poll..." : "Create Poll"}
-          </Button>
+          <Box display="flex" flexDirection="column" gap={2}>
+            <Button type="submit" variant="contained" disabled={isSubmitting}>
+              {isSubmitting ? "Creating Poll..." : "Create Poll"}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={showPreview ? <VisibilityOffIcon /> : <VisibilityIcon />}
+              onClick={(e) => {
+                e.preventDefault();
+                setShowPreview(!showPreview);
+              }}
+              fullWidth
+            >
+              {showPreview ? 'Hide Preview' : 'Show Preview'}
+            </Button>
+            <Collapse in={showPreview}>
+              <Box mt={1}>
+                <PollPreview pollEvent={previewEvent} />
+              </Box>
+            </Collapse>
+          </Box>
         </Box>
       </Stack>
     </form>


### PR DESCRIPTION
## Summary
Add real-time preview functionality to poll and note creation forms.

## Changes
- Create `PollPreview` and `NotePreview` components with collapsible UI
- Add preview toggle buttons to both `PollTemplateForm` and `NoteTemplateForm`
- Implement smooth transitions using Material-UI Collapse component

## Impact
- Users can preview content before publishing to Nostr
- Reduces publishing errors and improves creation confidence

---
*This pull request was created using GitHub Copilot.*