### PR TITLE
feat: Add user data persistence with TTL

### DIFF
--- a/src/components/Header/UserMenu.tsx
+++ b/src/components/Header/UserMenu.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { Avatar, Menu, MenuItem } from "@mui/material";
 import { useUserContext } from "../../hooks/useUserContext";
-import {
-  removeAppSecretFromLocalStorage,
-  removeBunkerUriFromLocalStorage,
-  removeKeysFromLocalStorage,
-} from "../../utils/localStorage";
 import { ColorSchemeToggle } from "../ColorScheme";
 import { styled } from "@mui/system";
 import { LoginModal } from "../Login/LoginModal";
 import { SettingsModal } from "./SettingsModal";
+import { useSigner } from "../../contexts/signer-context";
 
 const ListItem = styled("li")(() => ({
   padding: "0 16px",
@@ -19,13 +15,11 @@ export const UserMenu: React.FC = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [showLoginModal, setShowLoginModal] = React.useState(false);
   const [showSettings, setShowSettings] = React.useState(false);
-  const { user, setUser } = useUserContext();
+  const { user } = useUserContext();
+  const { logout } = useSigner();
 
   const handleLogOut = () => {
-    removeKeysFromLocalStorage();
-    removeBunkerUriFromLocalStorage();
-    removeAppSecretFromLocalStorage();
-    setUser(null);
+    logout();
     setAnchorEl(null);
   };
 

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -62,28 +62,29 @@ type UserData = {
 export const setUserDataInLocalStorage = (user: User, ttlInHours = 24) => {
   const now = new Date();
   const expiresAt = now.setHours(now.getHours() + ttlInHours);
-  
+
   const userData: UserData = {
     user,
     expiresAt,
   };
-  
-  localStorage.setItem(LOCAL_USER_DATA, JSON.stringify(userData));};
+
+  localStorage.setItem(LOCAL_USER_DATA, JSON.stringify(userData));
+};
 
 export const getUserDataFromLocalStorage = (): { user: User } | null => {
   const data = localStorage.getItem(LOCAL_USER_DATA);
   if (!data) return null;
-  
+
   try {
     const { user, expiresAt } = JSON.parse(data) as UserData;
     const isExpired = Date.now() > expiresAt;
-    
+
     // Remove expired data
     if (isExpired) {
       localStorage.removeItem(LOCAL_USER_DATA);
       return null;
     }
-    
+
     return { user };
   } catch (error) {
     console.error('Failed to parse user data from localStorage', error);

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,9 +1,11 @@
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { generateSecretKey } from "nostr-tools";
+import { User } from "../contexts/user-context";
 
 const LOCAL_STORAGE_KEYS = "pollerama:keys";
 const LOCAL_BUNKER_URI = "pollerama:bunkerUri";
 const LOCAL_APP_SECRET_KEY = "bunker:clientSecretKey";
+const LOCAL_USER_DATA = "pollerama:userData";
 
 type Keys = { pubkey: string; secret?: string };
 type BunkerUri = { bunkerUri: string };
@@ -50,4 +52,45 @@ export const removeBunkerUriFromLocalStorage = () => {
 
 export const removeAppSecretFromLocalStorage = () => {
   localStorage.removeItem(LOCAL_APP_SECRET_KEY);
+};
+
+type UserData = {
+  user: User;
+  expiresAt: number;
+};
+
+export const setUserDataInLocalStorage = (user: User, ttlInHours = 24) => {
+  const now = new Date();
+  const expiresAt = now.setHours(now.getHours() + ttlInHours);
+  
+  const userData: UserData = {
+    user,
+    expiresAt,
+  };
+  
+  localStorage.setItem(LOCAL_USER_DATA, JSON.stringify(userData));};
+
+export const getUserDataFromLocalStorage = (): { user: User } | null => {
+  const data = localStorage.getItem(LOCAL_USER_DATA);
+  if (!data) return null;
+  
+  try {
+    const { user, expiresAt } = JSON.parse(data) as UserData;
+    const isExpired = Date.now() > expiresAt;
+    
+    // Remove expired data
+    if (isExpired) {
+      localStorage.removeItem(LOCAL_USER_DATA);
+      return null;
+    }
+    
+    return { user };
+  } catch (error) {
+    console.error('Failed to parse user data from localStorage', error);
+    return null;
+  }
+};
+
+export const removeUserDataFromLocalStorage = () => {
+  localStorage.removeItem(LOCAL_USER_DATA);
 };


### PR DESCRIPTION
## Summary
Adds user data persistence with 24-hour TTL to cache profile data locally and reduce relay requests.

## Changes
- Added localStorage utilities with TTL support for user data caching
- Enhanced signer context to automatically cache user profiles during login
- Centralized logout functionality to clean up all stored data

## Impact
- Faster app initialization by loading cached profile data

---
*This pull request was created using GitHub Copilot.*