### PR TITLE
fix: Prevent multiple signer calls on movies feed login

### DIFF
--- a/src/components/Movies/MovieMetadataModal.tsx
+++ b/src/components/Movies/MovieMetadataModal.tsx
@@ -35,13 +35,13 @@ const MovieMetadataModal: React.FC<MovieMetadataModalProps> = ({
 
   useEffect(() => {
     const initialize = async () => {
-      if (!signer) return;
+      if (!signer || !open) return; // Only initialize when modal is actually open
       else {
         setPreviewEvent(await buildPreviewEvent());
       }
     };
     initialize();
-  }, [title, poster, year, summary, signer]);
+  }, [title, poster, year, summary, signer, open]);
   if (!signer) {
     return (
       <Modal open={open} onClose={onClose}>


### PR DESCRIPTION
## Summary
Fixes an issue where the signer was being called multiple times unnecessarily when user tried to login while on the movies feed.

## Changes
- Added `open` condition to initialization check in `MovieMetadataModal.tsx`
- Updated useEffect dependency array to include `open` state

## Impact
- Reduces redundant authentication calls and improves performance

---
*This pull request was created using GitHub Copilot.*